### PR TITLE
Fix Benchmark

### DIFF
--- a/benchmarks/src/main/scala/zio/cache/ChurnBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/cache/ChurnBenchmark.scala
@@ -44,7 +44,7 @@ class ChurnBenchmark extends BootstrapRuntime {
 
     cache = unsafeRun(
       for {
-        cache <- Cache.make(size, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(size, CachingPolicy.byLastAccess.flip, identityLookup)
         _     <- ZIO.foreach_(strings)(cache.get(_))
       } yield cache 
     )

--- a/zio-cache/shared/src/main/scala/zio/cache/CacheStats.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/CacheStats.scala
@@ -16,7 +16,7 @@ object CacheStats {
 
   val addHit: CacheStats => CacheStats = v => v.copy(hits = v.hits + 1L)
 
-  val addMiss: CacheStats => CacheStats = v => v.copy(hits = v.hits + 1L)
+  val addMiss: CacheStats => CacheStats = v => v.copy(misses = v.misses + 1L)
 
   def addLoadTime(time: Long): CacheStats => CacheStats = v => v.copy(loads = v.loads + time)
 


### PR DESCRIPTION
With the new semantics of the meaning of the ordering for `CachingPolicy` we need to flip the `CachingPolicy` in the churn benchmark so that we keep the oldest values in the cache and every attempt to put new values in the cache in the benchmark results in a cache miss.