### PR TITLE
Add Operators to Lookup

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.7
+sbt.version = 1.4.6

--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -149,8 +149,10 @@ object Cache {
 
                         (
                           trackMiss.flatMap(_ =>
-                            lookupValue
-                              .flatMap(exit => recordEntry(ref, now, key, EntryStats.make(now), exit))
+                            lookupValue.flatMap { exit =>
+                              if (lookup.include(key) == Lookup.Include.Never) ZIO.done(exit)
+                              else recordEntry(ref, now, key, EntryStats.make(now), exit)
+                            }
                           ),
                           state.copy(map = addAndPrune(now, state, key, promise))
                         )

--- a/zio-cache/shared/src/main/scala/zio/cache/Lookup.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Lookup.scala
@@ -1,10 +1,84 @@
 package zio.cache
 
-import zio.ZIO
+import zio._
 
 /**
  * A function that can lookup a value given a key, or possibly fail while trying.
  */
-final case class Lookup[-Key, -R, +E, +Value](value: Key => ZIO[R, E, Value]) extends (Key => ZIO[R, E, Value]) {
-  def apply(v1: Key): ZIO[R, E, Value] = value(v1)
+final case class Lookup[-Key, -R, +E, +Value](
+  lookup: Key => ZIO[R, E, Value],
+  include: Key => Lookup.Include
+) extends (Key => ZIO[R, E, Value]) { self =>
+  import Lookup._
+
+  /**
+   * Looks up the value for the given key.
+   */
+  def apply(key: Key): ZIO[R, E, Value] =
+    lookup(key)
+
+  /**
+   * Returns a new lookup function that will always cache keys matching the
+   * specified predicate.
+   */
+  def excludeKeys[Key1 <: Key](f: Key1 => Boolean): Lookup[Key1, R, E, Value] =
+    new Lookup(lookup, key => if (f(key)) Include.Never else include(key))
+
+  /**
+   * Returns a new lookup function that will never cache keys matching the
+   * specified predicate.
+   */
+  def includeKeys[Key1 <: Key](f: Key1 => Boolean): Lookup[Key1, R, E, Value] =
+    new Lookup(lookup, key => if (f(key)) Include.Always else include(key))
+
+  /**
+   * Returns a new lookup function that performs the function `f` every time a
+   * value is successfully looked up.
+   */
+  def onSuccess[R1 <: R](f: Value => URIO[R1, Any]): Lookup[Key, R1, E, Value] =
+    Lookup(key => lookup(key).tap(f))
+
+  /**
+   * Returns a new lookup function that performs the function `f` every time a
+   * failure occurs while looking up a value.
+   */
+  def onFailure[R1 <: R](f: E => URIO[R1, Any]): Lookup[Key, R1, E, Value] =
+    Lookup(key => lookup(key).tapError(f))
+
+  /**
+   * Combines this lookup function with the specified lookup function to
+   * return a new lookup function that tries to lookup the value for a given
+   * key using this lookup function, and if this lookup function fails tries
+   * to lookup the value for the given key using that lookup function.
+   */
+  def orElse[Key1 <: Key, R1 <: R, E2, Value1 >: Value](
+    that: => Lookup[Key1, R1, E2, Value1]
+  ): Lookup[Key1, R1, E2, Value1] =
+    Lookup(key => self.lookup(key).orElse(that.lookup(key)))
+
+  /**
+   * Combines this lookup function with the specified lookup function to
+   * return a new lookup function that tries to lookup the value for a given
+   * key using both this lookup function and that lookup function, returning
+   * the value from the first one to succeed and safely interrupting the
+   * other.
+   */
+  def race[Key1 <: Key, R1 <: R, E1 >: E, Value1 >: Value](
+    that: Lookup[Key1, R1, E1, Value1]
+  ): Lookup[Key1, R1, E1, Value1] =
+    Lookup(key => self.lookup(key).race(that.lookup(key)))
+}
+
+object Lookup {
+
+  def apply[Key, R, E, Value](lookup: Key => ZIO[R, E, Value]): Lookup[Key, R, E, Value] =
+    new Lookup(lookup, _ => Include.Sometimes)
+
+  sealed trait Include
+
+  object Include {
+    case object Always    extends Include
+    case object Never     extends Include
+    case object Sometimes extends Include
+  }
 }


### PR DESCRIPTION
Resolves #10.

Most of these operators are quite straightforward and in fact I think we could implement a lot of others such as `zipWith` and `zipWithPar` and if anything it is just a question of how much we want to duplicate from `ZIO`.

The ones that are somewhat less well defined are `IncludeKeys` and `ExcludeKeys`. I added a new algebraic data type representing whether a lookup result should be cached always, sometimes, or never and use that in the implementation of `Cache`. It isn't entirely clear to me what "always" means here. Does this mean it should be cached even if we subsequently say to exclude it? Or should it just undo excluding it, so that we would only need two cases of `Include` and `Exclude` and `Include` would be the default.

It is also not clear how these should compose. Right now in `race` or `orElse` whichever `Lookup` is ultimately used controls whether the value is cached which makes some sense, but if we implemented an operator like `zipWith` what would we do if one lookup function says "always cache me" and the other says "never cache me"?