### PR TITLE
Refactor Evict to not take the current time, Ttl class for specifying the Ttl of an Entry

### DIFF
--- a/benchmarks/src/main/scala/zio/cache/ChurnBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/cache/ChurnBenchmark.scala
@@ -47,7 +47,7 @@ class ChurnBenchmark extends BootstrapRuntime {
 
     cache = unsafeRun(
       for {
-        cache <- Cache.make(size, CachingPolicy.byLastAccess.flip, identityLookup)
+        cache <- Cache.make(size, CachingPolicy.byLastAccess.flip, Ttl.never, identityLookup)
         _     <- ZIO.foreach_(strings)(cache.get(_))
       } yield cache
     )

--- a/benchmarks/src/main/scala/zio/cache/FillBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/cache/FillBenchmark.scala
@@ -41,7 +41,7 @@ class FillBenchmark extends BootstrapRuntime {
   def zioCacheFill() =
     unsafeRun(
       for {
-        cache <- Cache.make(size, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(size, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _     <- ZIO.foreach_(strings)(cache.get(_))
         size0 <- cache.size
         _     <- ZIO.effect(Predef.assert(size0 == size))

--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -80,7 +80,7 @@ object Cache {
           case Exit.Success(value) =>
             val entry = Entry(entryStats, value)
 
-            if (policy.evict.evict(now, entry)) ref.update(state => state.copy(map = state.map - key)).as(value)
+            if (policy.evict.evict(entry)) ref.update(state => state.copy(map = state.map - key)).as(value)
             else
               ref.update { state =>
                 val newNow        = Instant.now()
@@ -158,7 +158,7 @@ object Cache {
                             .flatMap(exit => promise.done(exit).flatMap(_ => ZIO.succeedNow(exit)))
                             .provide(env)
 
-                        val stats = entryStats.getOrElse(key, EntryStats.make(now))
+                        val stats = entryStats.getOrElse(key, EntryStats.make(now, ttl = None))
 
                         (
                           trackMiss.flatMap(_ =>

--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -89,7 +89,7 @@ object Cache {
                 val newCacheStats = state.cacheStats.addLoad.addLoadTime(loadTime)
                 val newEntryStats = state.entryStats.updatedWith(key) {
                   case None        => None
-                  case Some(stats) => Some(stats.addLoad(loadTime).updateExpirationTime(ttl.ttl(key, value).map(t => now.plusMillis(t.toMillis))))
+                  case Some(stats) => Some(stats.addLoad(loadTime).updateExpirationTime(ttl.ttl(key, entry).map(t => now.plusMillis(t.toMillis))))
                 }
                 val newEntries = state.entries + ((key, value))
                 val newMap     = state.map.updated(key, MapValue.Complete(exit))

--- a/zio-cache/shared/src/main/scala/zio/cache/EntryStats.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/EntryStats.scala
@@ -44,13 +44,15 @@ final case class EntryStats(
 
   def updateLoadedTime(time: Instant): EntryStats =
     self.copy(loaded = time)
+
+  def updateExpirationTime(time: Option[Instant]): EntryStats =
+    self.copy(expirationTime = time)
 }
 
 object EntryStats {
 
-  def make(now: Instant,
-           ttl: Option[Duration]): EntryStats =
-    EntryStats(now, now, now, ttl.map(ttl => now.plusMillis(ttl.toMillis)), 1L, 0L, 0L, 0L, Duration.ZERO)
+  def make(now: Instant): EntryStats =
+    EntryStats(now, now, now, None, 1L, 0L, 0L, 0L, Duration.ZERO)
 
   def addHit(time: Instant): EntryStats => EntryStats =
     _.addHit(time)
@@ -63,4 +65,7 @@ object EntryStats {
 
   def updateLoadedTime(time: Instant): EntryStats => EntryStats =
     _.updateLoadedTime(time)
+
+  def updateExpirationTime(time: Option[Instant]): EntryStats => EntryStats =
+    _.updateExpirationTime(time)
 }

--- a/zio-cache/shared/src/main/scala/zio/cache/EntryStats.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/EntryStats.scala
@@ -22,6 +22,7 @@ final case class EntryStats(
   added: Instant,
   accessed: Instant,
   loaded: Instant,
+  expirationTime: Option[Instant],
   hits: Long,
   loads: Long,
   curSize: Long,
@@ -47,8 +48,9 @@ final case class EntryStats(
 
 object EntryStats {
 
-  def make(now: Instant): EntryStats =
-    EntryStats(now, now, now, 1L, 0L, 0L, 0L, Duration.ZERO)
+  def make(now: Instant,
+           ttl: Option[Duration]): EntryStats =
+    EntryStats(now, now, now, ttl.map(ttl => now.plusMillis(ttl.toMillis)), 1L, 0L, 0L, 0L, Duration.ZERO)
 
   def addHit(time: Instant): EntryStats => EntryStats =
     _.addHit(time)

--- a/zio-cache/shared/src/main/scala/zio/cache/Evict.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Evict.scala
@@ -1,38 +1,29 @@
 package zio.cache
 
-import java.time.{ Duration, Instant }
-
 /**
  * A `Evict` is used in deciding whether or not to keep a new entry that is looked up,
  * as well as deciding whether or not to keep existing entries that may have changed a lot since
  * they were loaded into the cache (too old, too infrequently used, etc.). It makes hard
  * decisions on cache entries: they should be purged, or they should be retained.
  */
-final case class Evict[-Value](evict: (Instant, Entry[Value]) => Boolean) { self =>
+final case class Evict[-Value](evict: Entry[Value] => Boolean) { self =>
   def &&[Value1 <: Value](that: Evict[Value1]): Evict[Value1] =
-    Evict[Value1]((n, v) => self.evict(n, v) && that.evict(n, v))
+    Evict[Value1]((v) => self.evict(v) && that.evict(v))
 
   def ||[Value1 <: Value](that: Evict[Value1]): Evict[Value1] =
-    Evict[Value1]((n, v) => self.evict(n, v) || that.evict(n, v))
+    Evict[Value1]((v) => self.evict(v) || that.evict(v))
 
   def unary_! : Evict[Value] =
-    Evict[Value]((n, v) => !self.evict(n, v))
+    Evict[Value]((v) => !self.evict(v))
 }
 object Evict {
 
-  val all: Evict[Any] = Evict[Any]((_, _) => true)
+  val all: Evict[Any] = Evict[Any](_ => true)
 
-  def equalTo[A](value: A): Evict[A] = Evict[A]((_, entry) => entry.value == value)
+  def equalTo[A](value: A): Evict[A] = Evict[A](entry => entry.value == value)
 
   def greaterThan(size: Long): Evict[Any] =
-    Evict[Any]((_, entry) => entry.entryStats.curSize >= size)
-
-  def olderThan(duration: Duration): Evict[Any] =
-    Evict[Any] { (now, entry) =>
-      val life = Duration.between(entry.entryStats.loaded, now)
-
-      life.compareTo(duration) >= 0
-    }
+    Evict[Any](entry => entry.entryStats.curSize >= size)
 
   val none: Evict[Any] = !all
 }

--- a/zio-cache/shared/src/main/scala/zio/cache/Example.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Example.scala
@@ -1,12 +1,9 @@
 package zio.cache
 
-import java.time.Duration
-
 object Example {
   import CachingPolicy._
 
   val evict =
-    Evict.olderThan(Duration.ofHours(1L)) && // newer than 1 hour
       Evict.greaterThan(100 * 1024 * 1024)   // smaller than 100 MB
 
   val policy =

--- a/zio-cache/shared/src/main/scala/zio/cache/Ttl.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Ttl.scala
@@ -4,14 +4,14 @@ import zio.duration._
 
 sealed abstract class Ttl[-Key, -Value] { self =>
 
-  def ttl(key: Key, value: Value): Option[Duration]
+  def ttl(key: Key, entry: Entry[Value]): Option[Duration]
 }
 
 object Ttl {
 
-  def apply[Key, Value](ttl0: (Key, Value) => Option[Duration]): Ttl[Key, Value] =
+  def apply[Key, Value](ttl0: (Key, Entry[Value]) => Option[Duration]): Ttl[Key, Value] =
     new Ttl[Key, Value] {
-      override def ttl(key: Key, value: Value): Option[Duration] = ttl0(key, value)
+      override def ttl(key: Key, entry: Entry[Value]): Option[Duration] = ttl0(key, entry)
     }
 
   val none: Ttl[Any, Any] = Ttl((_, _) => None)

--- a/zio-cache/shared/src/main/scala/zio/cache/Ttl.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Ttl.scala
@@ -1,0 +1,20 @@
+package zio.cache
+
+import zio.duration._
+
+sealed abstract class Ttl[-Key, -Value] { self =>
+
+  def ttl(key: Key, value: Value): Option[Duration]
+}
+
+object Ttl {
+
+  def apply[Key, Value](ttl0: (Key, Value) => Option[Duration]): Ttl[Key, Value] =
+    new Ttl[Key, Value] {
+      override def ttl(key: Key, value: Value): Option[Duration] = ttl0(key, value)
+    }
+
+  val none: Ttl[Any, Any] = Ttl((_, _) => None)
+
+  val never: Ttl[Any, Any] = none
+}

--- a/zio-cache/shared/src/test/scala/zio/cache/CacheGen.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CacheGen.scala
@@ -47,18 +47,20 @@ object CacheGen {
 
   lazy val genEntryStats: Gen[Random, EntryStats] =
     for {
-      added      <- genInstant
-      accessed   <- genInstant
-      loaded     <- genInstant
-      hits       <- genPositiveLong
-      loads      <- genPositiveLong
-      curSize    <- genPositiveLong
-      accSize    <- genPositiveLong
-      accLoading <- genDuration
+      added          <- genInstant
+      accessed       <- genInstant
+      loaded         <- genInstant
+      expirationTime <- genInstant
+      hits           <- genPositiveLong
+      loads          <- genPositiveLong
+      curSize        <- genPositiveLong
+      accSize        <- genPositiveLong
+      accLoading     <- genDuration
     } yield EntryStats(
       added,
       accessed,
       loaded,
+      Option(expirationTime),
       hits,
       loads,
       curSize,
@@ -67,7 +69,7 @@ object CacheGen {
     )
 
   lazy val genEvict: Gen[Random, Evict[Any]] =
-    Gen.function2[Random, Instant, Entry[Any], Boolean](genBoolean).map(Evict(_))
+    Gen.function[Random, Entry[Any], Boolean](genBoolean).map(Evict(_))
 
   lazy val genInstant: Gen[Random, Instant] =
     Gen.anyInstant

--- a/zio-cache/shared/src/test/scala/zio/cache/CachePolicySpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CachePolicySpec.scala
@@ -8,18 +8,18 @@ object CachePolicySpec extends DefaultRunnableSpec {
 
   def spec = suite("CachePolicySpec")(
     testM("++ is associative") {
-      check(genCachingPolicy, genCachingPolicy, genCachingPolicy, genInstant, genEntry, genEntry) {
-        (cachingPolicy1, cachingPolicy2, cachingPolicy3, now, l, r) =>
+      check(genCachingPolicy, genCachingPolicy, genCachingPolicy, genEntry, genEntry) {
+        (cachingPolicy1, cachingPolicy2, cachingPolicy3, l, r) =>
           val left  = (cachingPolicy1 ++ cachingPolicy2) ++ cachingPolicy3
           val right = cachingPolicy1 ++ (cachingPolicy2 ++ cachingPolicy3)
-          assert(left.compare(now, l, r))(equalTo(right.compare(now, l, r)))
+          assert(left.compare(l, r))(equalTo(right.compare(l, r)))
       }
     },
     testM("ordering of composing eviction policies is irrelevant") {
-      check(genCachingPolicy, genEvict, genInstant, genEntry, genEntry) { (cachingPolicy, evict, now, l, r) =>
+      check(genCachingPolicy, genEvict, genEntry, genEntry) { (cachingPolicy, evict, l, r) =>
         val left  = cachingPolicy ++ CachingPolicy.fromEvict(evict)
         val right = CachingPolicy.fromEvict(evict) ++ cachingPolicy
-        assert(left.compare(now, l, r))(equalTo(right.compare(now, l, r)))
+        assert(left.compare(l, r))(equalTo(right.compare(l, r)))
       }
     }
   )

--- a/zio-cache/shared/src/test/scala/zio/cache/CacheSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CacheSpec.scala
@@ -11,34 +11,34 @@ object CacheSpec extends DefaultRunnableSpec {
   def spec = suite("CacheSpec")(
     testM("get invokes lookup function") {
       for {
-        cache <- Cache.make(20, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(20, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         value <- cache.get("Sherlock")
       } yield assert(value)(equalTo("Sherlock"))
     },
     testM("get increases cache size") {
       for {
-        cache <- Cache.make(20, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(20, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _     <- cache.get("Sherlock")
         size  <- cache.size
       } yield assert(size)(equalTo(1))
     },
     testM("cache stores no more entries than capacity") {
       for {
-        cache <- Cache.make(1, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(1, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _     <- cache.get("Sherlock") *> cache.get("Holmes")
         size  <- cache.size
       } yield assert(size)(equalTo(1))
     },
     testM("cache will not store values that should be evicted") {
       for {
-        cache <- Cache.make(20, CachingPolicy(Priority.any, Evict.equalTo("Sherlock")), identityLookup)
+        cache <- Cache.make(20, CachingPolicy(Priority.any, Evict.equalTo("Sherlock")), Ttl.never, identityLookup)
         _     <- cache.get("Sherlock") *> cache.get("Holmes")
         size  <- cache.size
       } yield assert(size)(equalTo(1))
     },
     testM("cache will respecting priority when evicting on a full cache") {
       for {
-        cache <- Cache.make(1, CachingPolicy(Priority.fromOrderingValue[String], Evict.none), identityLookup)
+        cache <- Cache.make(1, CachingPolicy(Priority.fromOrderingValue[String], Evict.none), Ttl.never, identityLookup)
         _     <- cache.get("Apple") *> cache.get("Banana")
         rez1  <- cache.contains("Banana")
         rez2  <- cache.contains("Apple")

--- a/zio-cache/shared/src/test/scala/zio/cache/CacheStatsSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CacheStatsSpec.scala
@@ -11,7 +11,7 @@ object CacheStatsSpec extends DefaultRunnableSpec {
   def spec = suite("CacheStatsSpec")(
     testM("evictions") {
       for {
-        cache     <- Cache.make(1, CachingPolicy.byLastAccess, identityLookup)
+        cache     <- Cache.make(1, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _         <- cache.get("Sherlock")
         _         <- cache.get("Holmes")
         evictions <- cache.evictions
@@ -19,7 +19,7 @@ object CacheStatsSpec extends DefaultRunnableSpec {
     },
     testM("hits") {
       for {
-        cache <- Cache.make(20, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(20, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _     <- cache.get("Sherlock")
         _     <- cache.get("Sherlock")
         hits  <- cache.hits
@@ -27,7 +27,7 @@ object CacheStatsSpec extends DefaultRunnableSpec {
     },
     testM("cache loads") {
       for {
-        cache <- Cache.make(20, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(20, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _     <- cache.get("Sherlock")
         _     <- cache.get("Sherlock")
         loads <- cache.loads
@@ -35,7 +35,7 @@ object CacheStatsSpec extends DefaultRunnableSpec {
     },
     testM("entry loads") {
       for {
-        cache <- Cache.make(1, CachingPolicy.byLastAccess, identityLookup)
+        cache <- Cache.make(1, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _     <- cache.get("Sherlock")
         _     <- cache.get("Holmes")
         _     <- cache.get("Sherlock")
@@ -44,14 +44,14 @@ object CacheStatsSpec extends DefaultRunnableSpec {
     },
     testM("misses") {
       for {
-        cache  <- Cache.make(20, CachingPolicy.byLastAccess, identityLookup)
+        cache  <- Cache.make(20, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _      <- cache.get("Sherlock")
         misses <- cache.misses
       } yield assert(misses)(equalTo(1L))
     },
     testM("totalLoadTime") {
       for {
-        cache         <- Cache.make(20, CachingPolicy.byLastAccess, identityLookup)
+        cache         <- Cache.make(20, CachingPolicy.byLastAccess, Ttl.never, identityLookup)
         _             <- cache.get("Sherlock")
         totalLoadTime <- cache.totalLoadTime
       } yield assert(totalLoadTime.toNanos)(isGreaterThan(0L))

--- a/zio-cache/shared/src/test/scala/zio/cache/EvictSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/EvictSpec.scala
@@ -8,45 +8,45 @@ object EvictSpec extends DefaultRunnableSpec {
 
   def spec = suite("EvictSpec")(
     testM("&& is associative") {
-      check(genEvict, genEvict, genEvict, genInstant, genEntry) { (evict1, evict2, evict3, now, entry) =>
+      check(genEvict, genEvict, genEvict, genEntry) { (evict1, evict2, evict3, entry) =>
         val left  = (evict1 && evict2) && evict3
         val right = evict1 && (evict2 && evict3)
-        assert(left.evict(now, entry))(equalTo(right.evict(now, entry)))
+        assert(left.evict(entry))(equalTo(right.evict(entry)))
       }
     },
     testM("&& is commutative") {
-      check(genEvict, genEvict, genInstant, genEntry) { (evict1, evict2, now, entry) =>
+      check(genEvict, genEvict, genEntry) { (evict1, evict2, entry) =>
         val left  = evict1 && evict2
         val right = evict2 && evict1
-        assert(left.evict(now, entry))(equalTo(right.evict(now, entry)))
+        assert(left.evict(entry))(equalTo(right.evict(entry)))
       }
     },
     testM("all is an identity element with respect to &&") {
-      check(genEvict, genInstant, genEntry) { (evict, now, entry) =>
+      check(genEvict, genEntry) { (evict, entry) =>
         val left  = Evict.all && evict
         val right = evict && Evict.all
-        assert(left.evict(now, entry))(equalTo(right.evict(now, entry)))
+        assert(left.evict(entry))(equalTo(right.evict(entry)))
       }
     },
     testM("|| is associative") {
-      check(genEvict, genEvict, genEvict, genInstant, genEntry) { (evict1, evict2, evict3, now, entry) =>
+      check(genEvict, genEvict, genEvict, genEntry) { (evict1, evict2, evict3, entry) =>
         val left  = (evict1 || evict2) || evict3
         val right = evict1 || (evict2 || evict3)
-        assert(left.evict(now, entry))(equalTo(right.evict(now, entry)))
+        assert(left.evict(entry))(equalTo(right.evict(entry)))
       }
     },
     testM("|| is commutative") {
-      check(genEvict, genEvict, genInstant, genEntry) { (evict1, evict2, now, entry) =>
+      check(genEvict, genEvict, genEntry) { (evict1, evict2, entry) =>
         val left  = evict1 || evict2
         val right = evict2 || evict1
-        assert(left.evict(now, entry))(equalTo(right.evict(now, entry)))
+        assert(left.evict(entry))(equalTo(right.evict(entry)))
       }
     },
     testM("none is an identity element with respect to ||") {
-      check(genEvict, genInstant, genEntry) { (evict, now, entry) =>
+      check(genEvict, genEntry) { (evict, entry) =>
         val left  = Evict.none || evict
         val right = evict || Evict.none
-        assert(left.evict(now, entry))(equalTo(right.evict(now, entry)))
+        assert(left.evict(entry))(equalTo(right.evict(entry)))
       }
     }
   )


### PR DESCRIPTION
# Overview

This PR seeks to support 2 efforts:
1. Efficient TTL-based eviction by storing the expirationTime on the `EntryStats`, we will eventually be able to store a sorted list of items in the cache to be expired.
2. Per-entry TTL, different items in the cache should be able to expire at different times

This may resolve #6, further work will need to be done to store a TTL-ordered list of items *AND* build out a daemon fiber that evicts expired entries periodically. I would propose putting these changes into another issue though.

## Changes to `Evict`

Update the type signature of the `Evict.evict` method from:

```scala
evict: (Instant, Entry[Value]) => Boolean
```

to

```scala
evict: Entry[Value] => Boolean
```

## Changes to `EntryStats`

Add a new field `expirationTime`, which is an `Option[Instant]`.

## New Class: `Ttl[-Key, -Value]`

Create a new class `Ttl[-Key, -Value]` which takes in the key and value of a computed entry in the cache and produces an optional TTL:

```scala
sealed abstract class Ttl[-Key, -Value] { self =>

  def ttl(key: Key, entry: Entry[Value]): Option[Duration]
}
```

# Other Considerations

`Evict` can no longer evict based on current time, which means there is currently no mechanism to evict by any sort of TTL. This work is simply preparation to continue building on for adding in some sort of daemon fiber or other process for expiring entries based on the new `exiprationTime` field in `EntryStats`.