### PR TITLE
Remove `sealed` from `ManagedCache` abstract class

### DIFF
--- a/zio-cache/shared/src/main/scala/zio/cache/ManagedCache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/ManagedCache.scala
@@ -9,7 +9,7 @@ import java.util
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, LongAdder}
 import scala.jdk.CollectionConverters._
 
-sealed abstract class ManagedCache[-Key, +Error, +Value] {
+abstract class ManagedCache[-Key, +Error, +Value] {
 
   /**
    * Returns statistics for this cache.


### PR DESCRIPTION
It prevents us to use it

See https://discord.com/channels/629491597070827530/787129044336508988/998923648666705982