### PR TITLE
Add the possibility to use the Environment from the `ManagedLookup` in the `ManagedCache`

### DIFF
--- a/zio-cache/shared/src/test/scala/zio/cache/ManagedCacheSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/ManagedCacheSpec.scala
@@ -498,7 +498,7 @@ object ManagedCacheSpec extends DefaultRunnableSpec {
                   (_: Exit[Nothing, Unit]) =>
                     10.second
                 }
-                .use { (managedCache: ManagedCache[Unit, Nothing, Unit]) =>
+                .use { (managedCache: ManagedCache[Unit, Any, Nothing, Unit]) =>
                   val subManaged = managedCache.get(())
                   for {
                     _                               <- subManaged.use_(ZIO.unit)
@@ -526,7 +526,7 @@ object ManagedCacheSpec extends DefaultRunnableSpec {
                         .makeWith(10, ManagedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                           10.second
                         }
-                        .use { (managedCache: ManagedCache[Unit, Nothing, Unit]) =>
+                        .use { (managedCache: ManagedCache[Unit, Any, Nothing, Unit]) =>
                           val useGetManaged = managedCache.get(key = ()).use_(ZIO.unit)
                           for {
                             _                        <- useGetManaged
@@ -554,7 +554,7 @@ object ManagedCacheSpec extends DefaultRunnableSpec {
                         .makeWith(10, ManagedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                           10.second
                         }
-                        .use { (managedCache: ManagedCache[Unit, Nothing, Unit]) =>
+                        .use { (managedCache: ManagedCache[Unit, Any, Nothing, Unit]) =>
                           for {
                             Reservation(acquire, release)   <- managedCache.get(()).reserve
                             _                               <- acquire
@@ -579,7 +579,7 @@ object ManagedCacheSpec extends DefaultRunnableSpec {
                         .makeWith(10, ManagedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                           10.second
                         }
-                        .use { (managedCache: ManagedCache[Unit, Nothing, Unit]) =>
+                        .use { (managedCache: ManagedCache[Unit, Any, Nothing, Unit]) =>
                           for {
                             _            <- managedCache.get(key = ()).use_(ZIO.unit)
                             _            <- fakeClock.advance(9.second)
@@ -609,7 +609,7 @@ object ManagedCacheSpec extends DefaultRunnableSpec {
                         .makeWith(10, ManagedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                           10.second
                         }
-                        .use { (managedCache: ManagedCache[Unit, Nothing, Unit]) =>
+                        .use { (managedCache: ManagedCache[Unit, Any, Nothing, Unit]) =>
                           for {
                             _            <- managedCache.get(key = ()).use_(ZIO.unit)
                             _            <- fakeClock.advance(11.second)
@@ -637,7 +637,7 @@ object ManagedCacheSpec extends DefaultRunnableSpec {
                         .makeWith(10, ManagedLookup(watchableLookup.lookup), fakeClock) { (_: Exit[Nothing, Unit]) =>
                           10.second
                         }
-                        .use { (managedCache: ManagedCache[Unit, Nothing, Unit]) =>
+                        .use { (managedCache: ManagedCache[Unit, Any, Nothing, Unit]) =>
                           for {
                             Reservation(acquire, release) <- managedCache.get(key = ()).reserve
                             _                             <- acquire
@@ -943,7 +943,7 @@ object ManagedCacheSpec extends DefaultRunnableSpec {
     }
 
     def applyResourceOperations[V](
-      managedCache: ManagedCache[Key, Throwable, V],
+      managedCache: ManagedCache[Key, Any, Throwable, V],
       resourceOperations: List[ResourceOperation],
       ignoreCacheError: Boolean = false
     ): IO[TestFailure[Nothing], Map[ResourceId, Releaser]] =


### PR DESCRIPTION
To build a `ManagedCache`, you need to provide a `ManagedLookup`.
A `ManagedLookup` is defined as is:
```scala
final case class ManagedLookup[-Key, -Environment, +Error, +Value](lookup: Key => ZManaged[Environment, Error, Value])
    extends (Key => ZManaged[Environment, Error, Value])
```
But the `ManagedCache::get` method was returning a `Managed[Error, Value]` which was preventing us to use the `Environment` from the `ManagedLookup`

Now, the `ManagedCache::get` is returning `ZManaged[Environment, Error, Value]`

WDYT?