### PR TITLE
Optional jitter for the cache ttl

### DIFF
--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -95,6 +95,26 @@ abstract class Cache[-Key, +Error, +Value] {
   def size(implicit trace: Trace): UIO[Int]
 }
 
+object TimeToLive {
+
+  /**
+   * Returns a TTL function that adds randomized jitter to the base time to live.
+   *
+   * The `min` and `max` parameters control the bounds within which the base time to live
+   * is randomly scaled.
+   */
+  def jittered[Value](
+    timeToLive: Exit[Nothing, Value] => Duration,
+    min: Double,
+    max: Double
+  ): Exit[Nothing, Value] => Duration = { (exit: Exit[Nothing, Value]) =>
+    val d        = timeToLive(exit).toNanos
+    val random   = scala.util.Random.nextDouble()
+    val jittered = d * min * (1 - random) + d * max * random
+    zio.Duration.fromNanos(jittered.toLong)
+  }
+}
+
 object Cache {
 
   /**

--- a/zio-cache/shared/src/test/scala/zio/cache/CacheSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CacheSpec.scala
@@ -72,7 +72,26 @@ object CacheSpec extends ZIOSpecDefault {
             expected <- ZIO.foreachPar(1 to 100)(hash(salt))
           } yield assertTrue(actual == expected)
         }
-      }
+      },
+      test("jitter") {
+        check(Gen.int(20, 100)) { duration =>
+          for {
+            ref          <- Ref.make(0)
+            lookup        = Lookup((n: Int) => ref.updateAndGet(_ + 1).as(n))
+            cache        <- Cache.makeWith(10, lookup)(TimeToLive.jittered(_ => duration.seconds, 1, 2))
+            _            <- cache.get(1)
+            lookupCount1 <- ref.get
+            _            <- TestClock.adjust((duration / 10).seconds)
+            _            <- cache.get(1)
+            lookupCount2 <- ref.get
+            _            <- TestClock.adjust((duration * 2).seconds)
+            _            <- cache.get(1)
+            lookupCount3 <- ref.get
+          } yield assertTrue(
+            lookupCount1 == 1 && lookupCount2 == 1 && lookupCount3 == 2
+          )
+        }
+      } @@ TestAspect.samples(10)
     ),
     suite("`refresh` method")(
       test("should update the cache with a new value") {


### PR DESCRIPTION
Hi!
Here's a pull request to work towards closing issue #91.
If you find the suggested changes pull worthy, I would also make `ScopedCache` use the new `TimeToLive` parameter.