### PR TITLE
Ignore Scala 2.11 From Docs Project

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,12 +27,14 @@ jobs:
         distribution: temurin
         java-version: 17
         check-latest: true
-    - name: Check that site workflow is up to date
+    - name: Check if the README file is up to date
+      run: sbt  docs/checkReadme
+    - name: Check if the site workflow is up to date
       run: sbt  docs/checkGithubWorkflow
     - name: Check artifacts build process
       run: sbt  +publishLocal
     - name: Check website build process
-      run: sbt  docs/buildWebsite
+      run: sbt docs/clean; sbt  docs/buildWebsite
   publish-docs:
     name: Publish Docs
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,7 @@ lazy val docs = project
     moduleName := "zio-cache-docs",
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
+    crossScalaVersions -= "2.11.12",
     projectName                                := "ZIO Cache",
     mainModuleName                             := (zioCacheJVM / moduleName).value,
     projectStage                               := ProjectStage.Development,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                   
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.5.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.4.3")
-addSbtPlugin("dev.zio"                           % "zio-sbt-website"               % "0.3.2")
+addSbtPlugin("dev.zio"                           % "zio-sbt-website"               % "0.3.4")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.5"
 


### PR DESCRIPTION
This PR fixes the problem with publishing scaldoc when the scala version is 2.11

There remains an issue with the Scala-java-time library, and I have no idea how to resolve it.

/cc @guizmaii 