### PR TITLE
Add a method to refresh only if lookup is a success, not an error.

### DIFF
--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -311,8 +311,8 @@ object Cache {
               promise: Promise[Error, Value],
               /**
                * Left(()): Put the lookup result.
-               * Right(None): Remove key if there is a error.
-               * Right(Some(rollbackResult)): Rollback if there is a error.
+               * Right(None): Remove key if there is an error.
+               * Right(Some(rollbackResult)): Rollback if there is an error.
                */
               rollbackResultIfError: Either[Unit, Option[MapValue.Complete[Key, Error, Value]]] = Left(())
             ): IO[Error, Value] =

--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -323,11 +323,11 @@ object Cache {
                     rollbackResultIfError match {
                       case Some(rollbackResult) if exit.isFailure =>
                         map.put(key, rollbackResult)
-                        promise.done(rollbackResult.exit) *> ZIO.done(exit)
                       case _ =>
                         map.put(key, MapValue.Complete(new MapKey(key), exit, entryStats, now.plus(timeToLive(exit))))
-                        promise.done(exit) *> ZIO.done(exit)
                     }
+
+                    promise.done(exit) *> ZIO.done(exit)
                   }
                   .onInterrupt(promise.interrupt *> ZIO.succeed(map.remove(key)))
               }

--- a/zio-cache/shared/src/test/scala/zio/cache/CacheSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CacheSpec.scala
@@ -114,13 +114,17 @@ object CacheSpec extends ZIOSpecDefault {
           _        <- cache.refresh(key)
           val1     <- cache.get(key).either
           _        <- cache.refresh(key)
-          failure2 <- cache.refresh(key).either
-          _        <- cache.refresh(key)
           val2     <- cache.get(key).either
+          failure2 <- cache.refresh(key).either
+          failure3 <- cache.get(key).either
+          _        <- cache.refresh(key)
+          val3     <- cache.get(key).either
         } yield assert(failure1)(isLeft(equalTo(error))) &&
           assert(failure2)(isLeft(equalTo(error))) &&
+          assert(failure3)(isLeft(equalTo(error))) &&
           assert(val1)(isRight(equalTo(4))) &&
-          assert(val2)(isRight(equalTo(7)))
+          assert(val2)(isRight(equalTo(5))) &&
+          assert(val3)(isRight(equalTo(7)))
       },
       test("should get the value if the key doesn't exist in the cache") {
         check(Gen.int) { salt =>
@@ -132,6 +136,64 @@ object CacheSpec extends ZIOSpecDefault {
             count1 <- cache.size
           } yield assertTrue(count0 == 0) && assertTrue(count1 == cap)
         }
+      }
+    ),
+    suite("`refreshValue` method")(
+      test("should update the cache with a new value") {
+        def inc(n: Int) = n * 10
+
+        def retrieve(multiplier: Ref[Int])(key: Int) =
+          multiplier
+            .updateAndGet(inc)
+            .map(key * _)
+
+        val seed = 1
+        val key  = 123
+        for {
+          ref   <- Ref.make(seed)
+          cache <- Cache.make(1, Duration.Infinity, Lookup(retrieve(ref)))
+          val1  <- cache.get(key)
+          _     <- cache.refreshValue(key)
+          _     <- cache.get(key)
+          val2  <- cache.get(key)
+        } yield assertTrue(val1 == inc(key)) && assertTrue(val2 == inc(val1))
+      },
+      test("should update the cache only if lookup return a value, not an error.") {
+
+        val error = new RuntimeException("Must be a multiple of 3")
+
+        def inc(n: Int) = n + 1
+
+        def retrieve(number: Ref[Int])(key: Int) =
+          number
+            .updateAndGet(inc)
+            .flatMap {
+              case n if n % 3 == 0 =>
+                ZIO.fail(error)
+              case n =>
+                ZIO.succeed(key * n)
+            }
+
+        val seed = 2
+        val key  = 1
+        for {
+          ref      <- Ref.make(seed)
+          cache    <- Cache.make(1, Duration.Infinity, Lookup(retrieve(ref)))
+          failure1 <- cache.get(key).either
+          _        <- cache.refreshValue(key)
+          val1     <- cache.get(key).either
+          _        <- cache.refreshValue(key)
+          val2     <- cache.get(key).either
+          failure2 <- cache.refreshValue(key).either
+          val3     <- cache.get(key).either
+          _        <- cache.refreshValue(key)
+          val4     <- cache.get(key).either
+        } yield assert(failure1)(isLeft(equalTo(error))) &&
+          assert(failure2)(isLeft(equalTo(error))) &&
+          assert(val1)(isRight(equalTo(4))) &&
+          assert(val2)(isRight(equalTo(5))) &&
+          assert(val3)(isRight(equalTo(5))) &&
+          assert(val4)(isRight(equalTo(7)))
       }
     ),
     test("size") {


### PR DESCRIPTION
Added `def refreshValue(key: Key): IO[Error, Unit]` to keep old value in case of an error.