### PR TITLE
Ensure that accesses queue is empty when calling `trackAccess`

### DIFF
--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -286,32 +286,39 @@ object Cache {
       clock.unsafe.instant()(Unsafe).isAfter(timeToLive)
 
     private def trackAccess(key: MapKey[Key]): Unit = {
-      accesses.offer(key)
-      if (updating.compareAndSet(false, true)) {
-        var loop = true
-        while (loop) {
-          val key = accesses.poll(null)
-          if (key ne null) {
-            keys.add(key)
-          } else {
-            loop = false
-          }
-        }
-        var size = map.size
-        loop = size > capacity
-        while (loop) {
-          val key = keys.remove()
-          if (key ne null) {
-            if (map.remove(key.value) ne null) {
-              size -= 1
-              loop = size > capacity
+      @tailrec def loop(): Unit = {
+        if (updating.compareAndSet(false, true)) {
+          var loop = true
+          while (loop) {
+            val key = accesses.poll(null)
+            if (key ne null) {
+              keys.add(key)
+            } else {
+              loop = false
             }
-          } else {
-            loop = false
           }
+          var size = map.size
+          loop = size > capacity
+          while (loop) {
+            val key = keys.remove()
+            if (key ne null) {
+              if (map.remove(key.value) ne null) {
+                size -= 1
+                loop = size > capacity
+              }
+            } else {
+              loop = false
+            }
+          }
+          updating.set(false)
         }
-        updating.set(false)
+
+        // Someone might have added a key right after we drained the queue but before setting updating to `false`
+        if (!accesses.isEmpty()) loop() else ()
       }
+
+      accesses.offer(key)
+      loop()
     }
 
     private def trackHit(): Unit =


### PR DESCRIPTION
This seems like a bug to me. I think the only reason that it hasn't been reported is that it only really affects the outcome of `.size` under heavy contention for a very short period of time until the next time we call `trackAccess()`. Still, better to fix it.

Essentially we need to ensure that the queue is truly empty before we exit the `trackAccess()` method, as there is a chance another thread added an item by the time we finished draining the queue and until `updating.set(false)` is called