### PR TITLE
Remove metals.sbt files from git tracking

### DIFF
--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")


### PR DESCRIPTION
metals.sbt files are IDE-specific and should not be committed. They are already ignored by .gitignore.