### PR TITLE
Update ZIO and fix Scala 2.12 tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val allScalas = List("2.12", "2.13", "3.3")
 inThisBuild(
   List(
     name             := "ZIO Cache",
-    zioVersion       := "2.1.23",
+    zioVersion       := "2.1.24",
     scalaVersion     := scala213V,
     ciBackgroundJobs := Seq("free --si -tmws 10"),
     developers := List(

--- a/zio-cache/shared/src/test/scala/zio/cache/ScopedCacheSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/ScopedCacheSpec.scala
@@ -1032,7 +1032,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
     y => (x ^ y).hashCode
 
   object PropertyBaseTestingUtil {
-    type Key              = Char
+    type Key              = String
     type ResourceIdForKey = Int
     sealed trait ResourceOperation
     case class ResourceId(key: Key, resourceIdForKey: ResourceIdForKey)
@@ -1096,7 +1096,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
     }
 
     val balancedSequenceOfAcquireReleaseAndRefresh: Gen[Sized, List[ResourceOperation]] = {
-      val someKey                   = Gen.alphaChar
+      val someKey                   = Gen.alphaNumericString
       val numResourcesCreatedPerKey = Gen.int(1, 10)
       Gen.mapOf(someKey, numResourcesCreatedPerKey).flatMap { numPairByKey =>
         sequenceOfAcquireReleaseAndRefreshRec(
@@ -1110,7 +1110,7 @@ object ScopedCacheSpec extends ZIOSpecDefault {
     }
 
     val sequenceOfAcquireReleaseAndRefreshLettingSomeResourceUsed: Gen[Sized, ResourceOperationsAndResult] = {
-      val someKey                   = Gen.alphaChar
+      val someKey                   = Gen.alphaNumericString
       val numResourcesCreatedPerKey = Gen.int(1, 10)
       Gen.mapOf(someKey, numResourcesCreatedPerKey).flatMap { numPairByKey =>
         sequenceOfAcquireReleaseAndRefreshRec(


### PR DESCRIPTION
For some really unknown reason, using a `Char` as the key in a `Gen[Map[K, V]]` causes some weird failure in Scala 2.12. I'll investigate on ZIO's side what's going on, but in the meantime we can use a `String` as a key to get CI to pass