### PR TITLE
CI: Drop JDK 11, add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,9 @@ jobs:
       fail-fast: false
       matrix:
         java:
-        - '11'
+        - '17'
         - '21'
+        - '25'
         scala-project:
         - ++2.12 zioCacheJVM
         - ++2.13 zioCacheJVM

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ inThisBuild(
       )
     ),
     ciEnabledBranches    := Seq("series/2.x"),
-    ciTargetJavaVersions := List("11", "21"),
+    ciTargetJavaVersions := List("17", "21", "25"),
     ciTargetScalaVersions := Map(
       (zioCacheJVM / thisProject).value.id    -> allScalas,
       (zioCacheJS / thisProject).value.id     -> allScalas,


### PR DESCRIPTION
## Summary

- Drop JDK 11 from the CI test matrix as it has reached end of life
- Add JDK 25 to the CI test matrix
- The test matrix now runs against JDK 17, 21, and 25