### PR TITLE
Add CacheListener for observing cache events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,7 @@ lazy val docs = project
 lazy val enforceMimaCompatibility = true // Enable / disable failing CI on binary incompatibilities
 
 lazy val mimaFilters = Seq(
+  ProblemFilters.exclude[Problem]("zio.cache.Cache#CacheImplementation*"),
   ProblemFilters.exclude[Problem]("zio.cache.ScopedCacheImplementation#CacheState.map"),
   ProblemFilters.exclude[MissingClassProblem]("zio.cache.Platform*"),
   ProblemFilters.exclude[Problem]("zio.cache.Cache#CacheState*"),

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -78,3 +78,45 @@ Similarly, the `contains` operator returns whether a value associated with the s
 There are also the `cacheStats` and `entryStats` operators which allow obtaining a snapshot of statistics either for the cache itself or for a specified entry. See the sections on cache statistics and entry statistics for further discussion of this functionality.
 
 The `invalidate` and `invalidateAll` operators can be used to evict a value associated with a specified key and evict all values, respectively.
+
+```scala mdoc:reset:invisible
+```
+
+## Cache Events
+
+A `CacheListener` can be used to observe significant events in the lifecycle of a cache, for example to export cache activity to a metrics backend:
+
+```scala mdoc:compile-only
+import zio._
+
+sealed trait EvictionCause // Capacity, Expired, or Invalidated
+
+trait CacheListener[-Key, -Error, -Value] {
+  def onHit(key: Key)(implicit unsafe: Unsafe): Unit
+  def onMiss(key: Key)(implicit unsafe: Unsafe): Unit
+  def onLoad(key: Key, exit: Exit[Error, Value], loadTime: java.time.Duration)(implicit unsafe: Unsafe): Unit
+  def onEviction(key: Key, cause: EvictionCause)(implicit unsafe: Unsafe): Unit
+}
+```
+
+All methods have no-op default implementations, so a listener only needs to override the events it is interested in. Listeners are invoked synchronously on the hot path of the cache, so they must be fast, non-blocking, and must not throw exceptions.
+
+A listener is attached when the cache is constructed, using the overloads of `make`, `makeWith`, and `makeWithKey` that accept a `CacheListener`. The library also ships with a ready-made listener that reports cache events with ZIO metrics:
+
+```scala mdoc:compile-only
+import zio._
+import zio.cache._
+
+def timeConsumingEffect(key: String): UIO[Int] =
+  ZIO.sleep(5.seconds).as(key.hashCode)
+
+val cache: UIO[Cache[String, Nothing, Int]] =
+  Cache.make(
+    capacity = 100,
+    timeToLive = Duration.Infinity,
+    lookup = Lookup(timeConsumingEffect),
+    listener = CacheListener.metrics("user-cache")
+  )
+```
+
+The metrics listener reports `zio_cache_hits`, `zio_cache_misses`, `zio_cache_load_successes`, `zio_cache_load_failures`, `zio_cache_load_duration`, and `zio_cache_evictions`, all tagged with the specified cache name.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -92,14 +92,14 @@ import zio._
 sealed trait EvictionCause // Capacity, Expired, or Invalidated
 
 trait CacheListener[-Key, -Error, -Value] {
-  def onHit(key: Key)(implicit unsafe: Unsafe): Unit
-  def onMiss(key: Key)(implicit unsafe: Unsafe): Unit
-  def onLoad(key: Key, exit: Exit[Error, Value], loadTime: java.time.Duration)(implicit unsafe: Unsafe): Unit
-  def onEviction(key: Key, cause: EvictionCause)(implicit unsafe: Unsafe): Unit
+  def onHit(key: Key): UIO[Unit]
+  def onMiss(key: Key): UIO[Unit]
+  def onLoad(key: Key, exit: Exit[Error, Value], loadTime: java.time.Duration): UIO[Unit]
+  def onEviction(key: Key, cause: EvictionCause): UIO[Unit]
 }
 ```
 
-All methods have no-op default implementations, so a listener only needs to override the events it is interested in. Listeners are invoked synchronously on the hot path of the cache, so they must be fast, non-blocking, and must not throw exceptions.
+The effects returned by a listener are executed on the fiber interacting with the cache, potentially on its hot path, so they should be fast and non-blocking. A failure of a listener effect is logged and does not affect the operation of the cache.
 
 A listener is attached when the cache is constructed, using the overloads of `make`, `makeWith`, and `makeWithKey` that accept a `CacheListener`. The library also ships with a ready-made listener that reports cache events with ZIO metrics:
 

--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -24,7 +24,6 @@ import java.time.{Duration, Instant}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicBoolean, LongAdder}
 import scala.annotation.tailrec
-import scala.util.control.NonFatal
 
 /**
  * A `Cache` is defined in terms of a lookup function that, given a key of
@@ -236,7 +235,6 @@ object Cache {
     override def get(in: In)(implicit trace: Trace): IO[Error, Value] =
       ZIO.uninterruptibleMask(implicit res => getUnsafe(in))
 
-    @tailrec
     private def getUnsafe(in: In)(implicit restore: ZIO.InterruptibilityRestorer, trace: Trace): IO[Error, Value] = {
       val k                              = keyBy(in)
       var key: MapKey[Key]               = null
@@ -250,32 +248,28 @@ object Cache {
 
       value match {
         case null =>
-          trackAccess(key)
-          trackMiss(k)
-          lookupValueOf(in, k, promise)
+          trackAccess(key) *> trackMiss(k) *> lookupValueOf(in, k, promise)
         case MapValue.Pending(key, promise) =>
-          trackAccess(key)
-          trackHit(k)
-          restore(promise.await)
+          trackAccess(key) *> trackHit(k) *> restore(promise.await)
         case MapValue.Complete(key, exit, _, timeToLive) =>
-          trackAccess(key)
+          val accessed = trackAccess(key)
           if (hasExpired(timeToLive)) {
-            if (map.remove(k, value)) trackEviction(k, CacheListener.EvictionCause.Expired)
-            getUnsafe(in)
+            val evicted = if (map.remove(k, value)) trackEviction(k, CacheListener.EvictionCause.Expired) else Exit.unit
+            accessed *> evicted *> getUnsafe(in)
           } else {
-            trackHit(k)
-            exit
+            accessed *> trackHit(k) *> exit
           }
         case MapValue.Refreshing(
               promiseInProgress,
               MapValue.Complete(mapKey, currentResult, _, ttl)
             ) =>
-          trackAccess(mapKey)
-          trackHit(k)
-          if (hasExpired(ttl)) {
-            restore(promiseInProgress.await)
-          } else {
-            currentResult
+          val accessed = trackAccess(mapKey)
+          accessed *> trackHit(k) *> {
+            if (hasExpired(ttl)) {
+              restore(promiseInProgress.await)
+            } else {
+              currentResult
+            }
           }
       }
     }
@@ -295,8 +289,9 @@ object Cache {
             restore(promiseInProgress.await)
           case completedResult @ MapValue.Complete(_, _, _, ttl) =>
             if (hasExpired(ttl)) {
-              if (map.remove(k, value)) trackEviction(k, CacheListener.EvictionCause.Expired)
-              getUnsafe(in)
+              val evicted =
+                if (map.remove(k, value)) trackEviction(k, CacheListener.EvictionCause.Expired) else Exit.unit
+              evicted *> getUnsafe(in)
             } else {
               // Only trigger the lookup if we're still the current value, `completedResult`
               lookupValueOf(in, k, promise).whenDiscard {
@@ -309,13 +304,30 @@ object Cache {
       }
 
     override def invalidate(in: In)(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeed {
+      ZIO.suspendSucceed {
         val k = keyBy(in)
         if (map.remove(k) ne null) trackEviction(k, CacheListener.EvictionCause.Invalidated)
+        else Exit.unit
       }
 
     override def invalidateAll: UIO[Unit] =
-      ZIO.succeed(map.clear())
+      ZIO.suspendSucceed {
+        if (isNoopListener) {
+          map.clear()
+          Exit.unit
+        } else {
+          var invalidated: List[Key] = Nil
+          val iterator               = map.keySet().iterator()
+          while (iterator.hasNext) {
+            val key = iterator.next()
+            if (map.remove(key) ne null) {
+              invalidated = key :: invalidated
+            }
+          }
+          if (invalidated eq Nil) Exit.unit
+          else ZIO.foreachDiscard(invalidated)(key => trackEviction(key, CacheListener.EvictionCause.Invalidated))
+        }
+      }
 
     def size(implicit trace: Trace): UIO[Int] =
       ZIO.succeed(map.size)
@@ -332,16 +344,14 @@ object Cache {
               val interrupter = c.interruptOption.getOrElse(fiberId)
               promise.unsafe.interruptAs(interrupter)(trace, Unsafe)
               map.remove(key)
-              trackLoad(key, exit, startNanos)
-              exit
+              trackLoad(key, exit, startNanos) *> exit
             case exit =>
               val now        = clock.unsafe.instant()(Unsafe)
               val entryStats = EntryStats(now)
 
               map.put(key, MapValue.Complete(new MapKey(key), exit, entryStats, now.plus(timeToLive(exit))))
               promise.unsafe.done(exit)(Unsafe)
-              trackLoad(key, exit, startNanos)
-              exit
+              trackLoad(key, exit, startNanos) *> exit
           }
       }
 
@@ -351,8 +361,12 @@ object Cache {
     private def hasExpired(timeToLive: Instant) =
       clock.unsafe.instant()(Unsafe).isAfter(timeToLive)
 
-    private def trackAccess(key: MapKey[Key]): Unit = {
-      @tailrec def loop(): Unit = {
+    private def trackAccess(key: MapKey[Key]): UIO[Unit] = {
+      // Eviction notifications are collected while holding the `updating`
+      // flag and sequenced onto the calling fiber afterwards, so listener
+      // effects never run inside the lock.
+      @tailrec def loop(evicted0: List[Key]): List[Key] = {
+        var evicted = evicted0
         if (updating.compareAndSet(false, true)) {
           var loop = true
           while (loop) {
@@ -369,7 +383,7 @@ object Cache {
             val key = keys.remove()
             if (key ne null) {
               if (map.remove(key.value) ne null) {
-                trackEviction(key.value, CacheListener.EvictionCause.Capacity)
+                if (!isNoopListener) evicted = key.value :: evicted
                 size -= 1
                 loop = size > capacity
               }
@@ -381,38 +395,45 @@ object Cache {
         }
 
         // Someone might have added a key right after we drained the queue but before setting updating to `false`
-        if (!accesses.isEmpty()) loop() else ()
+        if (!accesses.isEmpty()) loop(evicted) else evicted
       }
 
       accesses.offer(key)
-      loop()
+      val evicted = loop(Nil)
+      if (evicted eq Nil) Exit.unit
+      else ZIO.foreachDiscard(evicted)(key => trackEviction(key, CacheListener.EvictionCause.Capacity))
     }
 
-    private def trackHit(key: Key): Unit = {
+    private def trackHit(key: Key): UIO[Unit] = {
       hits.increment()
-      notifyListener(listener.onHit(key)(Unsafe))
+      notifyListener(listener.onHit(key))
     }
 
-    private def trackMiss(key: Key): Unit = {
+    private def trackMiss(key: Key): UIO[Unit] = {
       misses.increment()
-      notifyListener(listener.onMiss(key)(Unsafe))
+      notifyListener(listener.onMiss(key))
     }
 
-    private def trackLoad(key: Key, exit: Exit[Error, Value], startNanos: Long): Unit =
+    private def trackLoad(key: Key, exit: Exit[Error, Value], startNanos: Long): UIO[Unit] =
       notifyListener {
         val loadTime = Duration.ofNanos(clock.unsafe.nanoTime()(Unsafe) - startNanos)
-        listener.onLoad(key, exit, loadTime)(Unsafe)
+        listener.onLoad(key, exit, loadTime)
       }
 
-    private def trackEviction(key: Key, cause: CacheListener.EvictionCause): Unit =
-      notifyListener(listener.onEviction(key, cause)(Unsafe))
+    private def trackEviction(key: Key, cause: CacheListener.EvictionCause): UIO[Unit] =
+      notifyListener(listener.onEviction(key, cause))
 
-    // Listeners must not throw but a listener that does anyway must not be
-    // able to corrupt the internal state of the cache or leave a promise
-    // uncompleted.
-    private def notifyListener(f: => Unit): Unit =
-      try f
-      catch { case NonFatal(_) => () }
+    private[this] val isNoopListener = listener eq CacheListener.noop
+
+    // A failing listener must not be able to affect the operation of the
+    // cache, so failures and defects of the listener effect are logged and
+    // discarded.
+    private def notifyListener(f: => UIO[Unit]): UIO[Unit] =
+      if (isNoopListener) Exit.unit
+      else
+        ZIO
+          .suspendSucceed(f)
+          .catchAllCause(cause => ZIO.logErrorCause("A CacheListener failed to process a cache event", cause))
   }
 
   /**

--- a/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/Cache.scala
@@ -24,6 +24,7 @@ import java.time.{Duration, Instant}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicBoolean, LongAdder}
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 
 /**
  * A `Cache` is defined in terms of a lookup function that, given a key of
@@ -109,6 +110,18 @@ object Cache {
     makeWith(capacity, lookup)(_ => timeToLive)
 
   /**
+   * Constructs a new cache with the specified capacity, time to live, lookup
+   * function, and listener that will be notified of cache events.
+   */
+  def make[Key, Environment, Error, Value](
+    capacity: Int,
+    timeToLive: Duration,
+    lookup: Lookup[Key, Environment, Error, Value],
+    listener: CacheListener[Key, Error, Value]
+  )(implicit trace: Trace): URIO[Environment, Cache[Key, Error, Value]] =
+    makeWith(capacity, lookup, listener)(_ => timeToLive)
+
+  /**
    * Constructs a new cache with the specified capacity, time to live, and
    * lookup function, where the time to live can depend on the `Exit` value
    * returned by the lookup function.
@@ -120,6 +133,21 @@ object Cache {
     timeToLive: Exit[Error, Value] => Duration
   )(implicit trace: Trace): URIO[Environment, Cache[Key, Error, Value]] =
     makeWithKey(capacity, lookup)(timeToLive, identity)
+
+  /**
+   * Constructs a new cache with the specified capacity, time to live, lookup
+   * function, and listener that will be notified of cache events, where the
+   * time to live can depend on the `Exit` value returned by the lookup
+   * function.
+   */
+  def makeWith[Key, Environment, Error, Value](
+    capacity: Int,
+    lookup: Lookup[Key, Environment, Error, Value],
+    listener: CacheListener[Key, Error, Value]
+  )(
+    timeToLive: Exit[Error, Value] => Duration
+  )(implicit trace: Trace): URIO[Environment, Cache[Key, Error, Value]] =
+    makeWithKey(capacity, lookup, listener)(timeToLive, identity)
 
   /**
    * Constructs a new cache with the specified capacity, time to live, and
@@ -138,10 +166,33 @@ object Cache {
     timeToLive: Exit[Error, Value] => Duration,
     keyBy: In => Key
   )(implicit trace: Trace): URIO[Environment, Cache[In, Error, Value]] =
+    makeWithKey(capacity, lookup, CacheListener.noop)(timeToLive, keyBy)
+
+  /**
+   * Constructs a new cache with the specified capacity, time to live, lookup
+   * function, and listener that will be notified of cache events, where the
+   * time to live can depend on the `Exit` value returned by the lookup
+   * function.
+   *
+   * This variant also allows specifying a custom keying function that will be
+   * used to to convert the input of the lookup function into the key in the
+   * underlying cache. This can be useful when the input to the lookup function
+   * is large and you do not want to store it in the cache. The listener will
+   * be notified with the keys in the underlying cache, that is, the keys
+   * produced by the keying function.
+   */
+  def makeWithKey[In, Key, Environment, Error, Value](
+    capacity: Int,
+    lookup: Lookup[In, Environment, Error, Value],
+    listener: CacheListener[Key, Error, Value]
+  )(
+    timeToLive: Exit[Error, Value] => Duration,
+    keyBy: In => Key
+  )(implicit trace: Trace): URIO[Environment, Cache[In, Error, Value]] =
     ZIO.clockWith { clock =>
       ZIO.environmentWithZIO[Environment] { environment =>
         ZIO.fiberId.map { fiberId =>
-          new CacheImplementation(capacity, lookup, timeToLive, keyBy, clock, environment, fiberId)
+          new CacheImplementation(capacity, lookup, timeToLive, keyBy, clock, environment, fiberId, listener)
         }
       }
     }
@@ -153,7 +204,8 @@ object Cache {
     keyBy: In => Key,
     clock: Clock,
     environment: ZEnvironment[Environment],
-    fiberId: FiberId.Runtime
+    fiberId: FiberId.Runtime,
+    listener: CacheListener[Key, Error, Value]
   )(implicit trace: Trace)
       extends Cache[In, Error, Value] {
 
@@ -199,19 +251,19 @@ object Cache {
       value match {
         case null =>
           trackAccess(key)
-          trackMiss()
+          trackMiss(k)
           lookupValueOf(in, k, promise)
         case MapValue.Pending(key, promise) =>
           trackAccess(key)
-          trackHit()
+          trackHit(k)
           restore(promise.await)
         case MapValue.Complete(key, exit, _, timeToLive) =>
           trackAccess(key)
           if (hasExpired(timeToLive)) {
-            map.remove(k, value)
+            if (map.remove(k, value)) trackEviction(k, CacheListener.EvictionCause.Expired)
             getUnsafe(in)
           } else {
-            trackHit()
+            trackHit(k)
             exit
           }
         case MapValue.Refreshing(
@@ -219,7 +271,7 @@ object Cache {
               MapValue.Complete(mapKey, currentResult, _, ttl)
             ) =>
           trackAccess(mapKey)
-          trackHit()
+          trackHit(k)
           if (hasExpired(ttl)) {
             restore(promiseInProgress.await)
           } else {
@@ -243,7 +295,7 @@ object Cache {
             restore(promiseInProgress.await)
           case completedResult @ MapValue.Complete(_, _, _, ttl) =>
             if (hasExpired(ttl)) {
-              map.remove(k, value)
+              if (map.remove(k, value)) trackEviction(k, CacheListener.EvictionCause.Expired)
               getUnsafe(in)
             } else {
               // Only trigger the lookup if we're still the current value, `completedResult`
@@ -257,7 +309,10 @@ object Cache {
       }
 
     override def invalidate(in: In)(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeed(map.remove(keyBy(in)): Unit)
+      ZIO.succeed {
+        val k = keyBy(in)
+        if (map.remove(k) ne null) trackEviction(k, CacheListener.EvictionCause.Invalidated)
+      }
 
     override def invalidateAll: UIO[Unit] =
       ZIO.succeed(map.clear())
@@ -268,22 +323,27 @@ object Cache {
     private def lookupValueOf(in: In, key: Key, promise: Promise[Error, Value])(implicit
       restore: ZIO.InterruptibilityRestorer
     ): IO[Error, Value] =
-      restore(lookup(in))
-        .provideEnvironment(environment)
-        .exitWith {
-          case exit @ Exit.Failure(c) if c.isInterruptedOnly =>
-            val interrupter = c.interruptOption.getOrElse(fiberId)
-            promise.unsafe.interruptAs(interrupter)(trace, Unsafe)
-            map.remove(key)
-            exit
-          case exit =>
-            val now        = clock.unsafe.instant()(Unsafe)
-            val entryStats = EntryStats(now)
+      ZIO.suspendSucceed {
+        val startNanos = clock.unsafe.nanoTime()(Unsafe)
+        restore(lookup(in))
+          .provideEnvironment(environment)
+          .exitWith {
+            case exit @ Exit.Failure(c) if c.isInterruptedOnly =>
+              val interrupter = c.interruptOption.getOrElse(fiberId)
+              promise.unsafe.interruptAs(interrupter)(trace, Unsafe)
+              map.remove(key)
+              trackLoad(key, exit, startNanos)
+              exit
+            case exit =>
+              val now        = clock.unsafe.instant()(Unsafe)
+              val entryStats = EntryStats(now)
 
-            map.put(key, MapValue.Complete(new MapKey(key), exit, entryStats, now.plus(timeToLive(exit))))
-            promise.unsafe.done(exit)(Unsafe)
-            exit
-        }
+              map.put(key, MapValue.Complete(new MapKey(key), exit, entryStats, now.plus(timeToLive(exit))))
+              promise.unsafe.done(exit)(Unsafe)
+              trackLoad(key, exit, startNanos)
+              exit
+          }
+      }
 
     private def newPromise() =
       Promise.unsafe.make[Error, Value](fiberId)(Unsafe)
@@ -309,6 +369,7 @@ object Cache {
             val key = keys.remove()
             if (key ne null) {
               if (map.remove(key.value) ne null) {
+                trackEviction(key.value, CacheListener.EvictionCause.Capacity)
                 size -= 1
                 loop = size > capacity
               }
@@ -327,11 +388,31 @@ object Cache {
       loop()
     }
 
-    private def trackHit(): Unit =
+    private def trackHit(key: Key): Unit = {
       hits.increment()
+      notifyListener(listener.onHit(key)(Unsafe))
+    }
 
-    private def trackMiss(): Unit =
+    private def trackMiss(key: Key): Unit = {
       misses.increment()
+      notifyListener(listener.onMiss(key)(Unsafe))
+    }
+
+    private def trackLoad(key: Key, exit: Exit[Error, Value], startNanos: Long): Unit =
+      notifyListener {
+        val loadTime = Duration.ofNanos(clock.unsafe.nanoTime()(Unsafe) - startNanos)
+        listener.onLoad(key, exit, loadTime)(Unsafe)
+      }
+
+    private def trackEviction(key: Key, cause: CacheListener.EvictionCause): Unit =
+      notifyListener(listener.onEviction(key, cause)(Unsafe))
+
+    // Listeners must not throw but a listener that does anyway must not be
+    // able to corrupt the internal state of the cache or leave a promise
+    // uncompleted.
+    private def notifyListener(f: => Unit): Unit =
+      try f
+      catch { case NonFatal(_) => () }
   }
 
   /**

--- a/zio-cache/shared/src/main/scala/zio/cache/CacheListener.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/CacheListener.scala
@@ -17,7 +17,7 @@
 package zio.cache
 
 import zio.metrics.Metric
-import zio.{Exit, Unsafe}
+import zio.{Exit, UIO}
 
 import java.time.Duration
 import java.time.temporal.ChronoUnit
@@ -28,12 +28,10 @@ import java.time.temporal.ChronoUnit
  * used to export cache activity to a metrics backend or to any other
  * monitoring infrastructure.
  *
- * Listener methods are invoked synchronously on the fiber interacting with
- * the cache, potentially on its hot path, so implementations must be fast,
- * non-blocking, and must not throw exceptions. Any exceptions thrown by a
- * listener will be ignored. All methods have no-op default implementations
- * so implementations only need to override the events they are interested
- * in.
+ * The effects returned by a listener are executed on the fiber interacting
+ * with the cache, potentially on its hot path, so they should be fast and
+ * non-blocking. A failure of a listener effect is logged and does not affect
+ * the operation of the cache.
  */
 trait CacheListener[-Key, -Error, -Value] {
 
@@ -41,30 +39,26 @@ trait CacheListener[-Key, -Error, -Value] {
    * Called when a value associated with the specified key is found in the
    * cache.
    */
-  def onHit(key: Key)(implicit unsafe: Unsafe): Unit =
-    ()
+  def onHit(key: Key): UIO[Unit]
 
   /**
    * Called when no value associated with the specified key is found in the
    * cache and the lookup function will be triggered.
    */
-  def onMiss(key: Key)(implicit unsafe: Unsafe): Unit =
-    ()
+  def onMiss(key: Key): UIO[Unit]
 
   /**
    * Called when a lookup completes, whether triggered by `get` or by
    * `refresh`, with the `Exit` value produced by the lookup function and the
    * time the lookup took.
    */
-  def onLoad(key: Key, exit: Exit[Error, Value], loadTime: Duration)(implicit unsafe: Unsafe): Unit =
-    ()
+  def onLoad(key: Key, exit: Exit[Error, Value], loadTime: Duration): UIO[Unit]
 
   /**
    * Called when an entry associated with the specified key is removed from
-   * the cache. Note that no events are emitted by `invalidateAll`.
+   * the cache.
    */
-  def onEviction(key: Key, cause: CacheListener.EvictionCause)(implicit unsafe: Unsafe): Unit =
-    ()
+  def onEviction(key: Key, cause: CacheListener.EvictionCause): UIO[Unit]
 }
 
 object CacheListener {
@@ -97,7 +91,12 @@ object CacheListener {
    * A listener that ignores all events.
    */
   val noop: CacheListener[Any, Any, Any] =
-    new CacheListener[Any, Any, Any] {}
+    new CacheListener[Any, Any, Any] {
+      def onHit(key: Any): UIO[Unit]                                            = Exit.unit
+      def onMiss(key: Any): UIO[Unit]                                           = Exit.unit
+      def onLoad(key: Any, exit: Exit[Any, Any], loadTime: Duration): UIO[Unit] = Exit.unit
+      def onEviction(key: Any, cause: EvictionCause): UIO[Unit]                 = Exit.unit
+    }
 
   /**
    * A listener that reports cache events with ZIO metrics, tagging each
@@ -126,23 +125,21 @@ object CacheListener {
       private val expiredEvictions     = evictions.tagged("cause", "expired")
       private val invalidatedEvictions = evictions.tagged("cause", "invalidated")
 
-      override def onHit(key: Any)(implicit unsafe: Unsafe): Unit =
-        hits.unsafe.update(1L)
+      def onHit(key: Any): UIO[Unit] =
+        hits.update(1L)
 
-      override def onMiss(key: Any)(implicit unsafe: Unsafe): Unit =
-        misses.unsafe.update(1L)
+      def onMiss(key: Any): UIO[Unit] =
+        misses.update(1L)
 
-      override def onLoad(key: Any, exit: Exit[Any, Any], loadTime: Duration)(implicit unsafe: Unsafe): Unit = {
-        if (exit.isSuccess) loadSuccesses.unsafe.update(1L)
-        else loadFailures.unsafe.update(1L)
-        loadDuration.unsafe.update(loadTime)
-      }
+      def onLoad(key: Any, exit: Exit[Any, Any], loadTime: Duration): UIO[Unit] =
+        (if (exit.isSuccess) loadSuccesses.update(1L) else loadFailures.update(1L)) *>
+          loadDuration.update(loadTime)
 
-      override def onEviction(key: Any, cause: EvictionCause)(implicit unsafe: Unsafe): Unit =
+      def onEviction(key: Any, cause: EvictionCause): UIO[Unit] =
         cause match {
-          case EvictionCause.Capacity    => capacityEvictions.unsafe.update(1L)
-          case EvictionCause.Expired     => expiredEvictions.unsafe.update(1L)
-          case EvictionCause.Invalidated => invalidatedEvictions.unsafe.update(1L)
+          case EvictionCause.Capacity    => capacityEvictions.update(1L)
+          case EvictionCause.Expired     => expiredEvictions.update(1L)
+          case EvictionCause.Invalidated => invalidatedEvictions.update(1L)
         }
     }
 }

--- a/zio-cache/shared/src/main/scala/zio/cache/CacheListener.scala
+++ b/zio-cache/shared/src/main/scala/zio/cache/CacheListener.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020-2023 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.cache
+
+import zio.metrics.Metric
+import zio.{Exit, Unsafe}
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+/**
+ * A `CacheListener` is notified of significant events in the lifecycle of a
+ * cache, such as hits, misses, completed lookups, and evictions. It can be
+ * used to export cache activity to a metrics backend or to any other
+ * monitoring infrastructure.
+ *
+ * Listener methods are invoked synchronously on the fiber interacting with
+ * the cache, potentially on its hot path, so implementations must be fast,
+ * non-blocking, and must not throw exceptions. Any exceptions thrown by a
+ * listener will be ignored. All methods have no-op default implementations
+ * so implementations only need to override the events they are interested
+ * in.
+ */
+trait CacheListener[-Key, -Error, -Value] {
+
+  /**
+   * Called when a value associated with the specified key is found in the
+   * cache.
+   */
+  def onHit(key: Key)(implicit unsafe: Unsafe): Unit =
+    ()
+
+  /**
+   * Called when no value associated with the specified key is found in the
+   * cache and the lookup function will be triggered.
+   */
+  def onMiss(key: Key)(implicit unsafe: Unsafe): Unit =
+    ()
+
+  /**
+   * Called when a lookup completes, whether triggered by `get` or by
+   * `refresh`, with the `Exit` value produced by the lookup function and the
+   * time the lookup took.
+   */
+  def onLoad(key: Key, exit: Exit[Error, Value], loadTime: Duration)(implicit unsafe: Unsafe): Unit =
+    ()
+
+  /**
+   * Called when an entry associated with the specified key is removed from
+   * the cache. Note that no events are emitted by `invalidateAll`.
+   */
+  def onEviction(key: Key, cause: CacheListener.EvictionCause)(implicit unsafe: Unsafe): Unit =
+    ()
+}
+
+object CacheListener {
+
+  /**
+   * The cause of the removal of an entry from the cache.
+   */
+  sealed trait EvictionCause extends Product with Serializable
+
+  object EvictionCause {
+
+    /**
+     * The entry was removed because the cache was at capacity and the entry
+     * was one of the least recently accessed.
+     */
+    case object Capacity extends EvictionCause
+
+    /**
+     * The entry was removed because it was older than its time to live.
+     */
+    case object Expired extends EvictionCause
+
+    /**
+     * The entry was removed because it was explicitly invalidated.
+     */
+    case object Invalidated extends EvictionCause
+  }
+
+  /**
+   * A listener that ignores all events.
+   */
+  val noop: CacheListener[Any, Any, Any] =
+    new CacheListener[Any, Any, Any] {}
+
+  /**
+   * A listener that reports cache events with ZIO metrics, tagging each
+   * metric with the specified cache name. The following metrics are
+   * reported:
+   *
+   *   - `<prefix>hits` — counter of cache hits
+   *   - `<prefix>misses` — counter of cache misses
+   *   - `<prefix>load_successes` — counter of successfully completed lookups
+   *   - `<prefix>load_failures` — counter of failed lookups
+   *   - `<prefix>load_duration` — histogram of lookup durations
+   *   - `<prefix>evictions` — counter of evictions, tagged with the eviction
+   *     cause
+   */
+  def metrics(cacheName: String, prefix: String = "zio_cache_"): CacheListener[Any, Any, Any] =
+    new CacheListener[Any, Any, Any] {
+      private val hits          = Metric.counter(prefix + "hits").tagged("cache_name", cacheName)
+      private val misses        = Metric.counter(prefix + "misses").tagged("cache_name", cacheName)
+      private val loadSuccesses = Metric.counter(prefix + "load_successes").tagged("cache_name", cacheName)
+      private val loadFailures  = Metric.counter(prefix + "load_failures").tagged("cache_name", cacheName)
+      private val loadDuration =
+        Metric.timer(prefix + "load_duration", ChronoUnit.MILLIS).tagged("cache_name", cacheName)
+      private val evictions = Metric.counter(prefix + "evictions").tagged("cache_name", cacheName)
+
+      private val capacityEvictions    = evictions.tagged("cause", "capacity")
+      private val expiredEvictions     = evictions.tagged("cause", "expired")
+      private val invalidatedEvictions = evictions.tagged("cause", "invalidated")
+
+      override def onHit(key: Any)(implicit unsafe: Unsafe): Unit =
+        hits.unsafe.update(1L)
+
+      override def onMiss(key: Any)(implicit unsafe: Unsafe): Unit =
+        misses.unsafe.update(1L)
+
+      override def onLoad(key: Any, exit: Exit[Any, Any], loadTime: Duration)(implicit unsafe: Unsafe): Unit = {
+        if (exit.isSuccess) loadSuccesses.unsafe.update(1L)
+        else loadFailures.unsafe.update(1L)
+        loadDuration.unsafe.update(loadTime)
+      }
+
+      override def onEviction(key: Any, cause: EvictionCause)(implicit unsafe: Unsafe): Unit =
+        cause match {
+          case EvictionCause.Capacity    => capacityEvictions.unsafe.update(1L)
+          case EvictionCause.Expired     => expiredEvictions.unsafe.update(1L)
+          case EvictionCause.Invalidated => invalidatedEvictions.unsafe.update(1L)
+        }
+    }
+}

--- a/zio-cache/shared/src/test/scala/zio/cache/CacheListenerSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CacheListenerSpec.scala
@@ -1,0 +1,187 @@
+package zio.cache
+
+import zio._
+import zio.cache.CacheListener.EvictionCause
+import zio.metrics.Metric
+import zio.test._
+
+import java.time.{Duration => JDuration}
+import java.util.concurrent.atomic.AtomicInteger
+
+object CacheListenerSpec extends ZIOSpecDefault {
+
+  final class TestListener extends CacheListener[Any, Any, Any] {
+    val hits          = new AtomicInteger(0)
+    val misses        = new AtomicInteger(0)
+    val loadSuccesses = new AtomicInteger(0)
+    val loadFailures  = new AtomicInteger(0)
+    val capacity      = new AtomicInteger(0)
+    val expired       = new AtomicInteger(0)
+    val invalidated   = new AtomicInteger(0)
+
+    override def onHit(key: Any)(implicit unsafe: Unsafe): Unit = {
+      hits.incrementAndGet()
+      ()
+    }
+
+    override def onMiss(key: Any)(implicit unsafe: Unsafe): Unit = {
+      misses.incrementAndGet()
+      ()
+    }
+
+    override def onLoad(key: Any, exit: Exit[Any, Any], loadTime: JDuration)(implicit unsafe: Unsafe): Unit = {
+      if (exit.isSuccess) loadSuccesses.incrementAndGet() else loadFailures.incrementAndGet()
+      ()
+    }
+
+    override def onEviction(key: Any, cause: EvictionCause)(implicit unsafe: Unsafe): Unit = {
+      cause match {
+        case EvictionCause.Capacity    => capacity.incrementAndGet()
+        case EvictionCause.Expired     => expired.incrementAndGet()
+        case EvictionCause.Invalidated => invalidated.incrementAndGet()
+      }
+      ()
+    }
+  }
+
+  def hash(x: Int): Int => UIO[Int] =
+    y => ZIO.succeed((x ^ y).hashCode)
+
+  val identity: Int => UIO[Int] =
+    ZIO.succeed(_)
+
+  def spec: Spec[TestEnvironment with Scope, Any] = suite("CacheListenerSpec")(
+    test("hit, miss, and load events") {
+      check(Gen.int) { salt =>
+        val listener = new TestListener
+        for {
+          cache <- Cache.make(100, Duration.Infinity, Lookup(hash(salt)), listener)
+          _     <- ZIO.foreachParDiscard((1 to 100).map(_ / 2))(cache.get)
+        } yield assertTrue(
+          listener.hits.get == 49,
+          listener.misses.get == 51,
+          listener.loadSuccesses.get == 51,
+          listener.loadFailures.get == 0
+        )
+      }
+    },
+    test("failed loads are cached and reported once") {
+      val error    = new RuntimeException("boom")
+      val listener = new TestListener
+      for {
+        cache    <- Cache.make(100, Duration.Infinity, Lookup((_: Int) => ZIO.fail(error)), listener)
+        failure1 <- cache.get(42).either
+        failure2 <- cache.get(42).either
+      } yield assertTrue(
+        failure1 == Left(error),
+        failure2 == Left(error),
+        listener.misses.get == 1,
+        listener.hits.get == 1,
+        listener.loadFailures.get == 1,
+        listener.loadSuccesses.get == 0
+      )
+    },
+    test("load events are emitted for refreshes") {
+      val listener = new TestListener
+      for {
+        cache <- Cache.make(100, Duration.Infinity, Lookup(identity), listener)
+        _     <- cache.get(42)
+        _     <- cache.refresh(42)
+      } yield assertTrue(
+        listener.loadSuccesses.get == 2,
+        listener.misses.get == 1
+      )
+    },
+    test("eviction events when the cache is at capacity") {
+      check(Gen.int) { salt =>
+        val listener = new TestListener
+        for {
+          cache <- Cache.make(10, Duration.Infinity, Lookup(hash(salt)), listener)
+          _     <- ZIO.foreachDiscard(1 to 100)(cache.get)
+          size  <- cache.size
+        } yield assertTrue(
+          size == 10,
+          listener.capacity.get == 90,
+          listener.expired.get == 0,
+          listener.invalidated.get == 0
+        )
+      }
+    },
+    test("eviction events for expired entries") {
+      val listener = new TestListener
+      for {
+        cache <- Cache.make(100, 1.second, Lookup(identity), listener)
+        _     <- cache.get(42)
+        _     <- TestClock.adjust(2.seconds)
+        _     <- cache.get(42)
+      } yield assertTrue(
+        listener.expired.get == 1,
+        listener.misses.get == 2,
+        listener.hits.get == 0
+      )
+    },
+    test("eviction events for invalidated entries") {
+      val listener = new TestListener
+      for {
+        cache <- Cache.make(100, Duration.Infinity, Lookup(identity), listener)
+        _     <- cache.get(42)
+        _     <- cache.invalidate(42)
+        _     <- cache.invalidate(43)
+      } yield assertTrue(listener.invalidated.get == 1)
+    },
+    test("listener is notified with the keys produced by the keying function") {
+      val listener = new TestListener
+      for {
+        cache <- Cache.makeWithKey(100, Lookup((in: (Int, String)) => ZIO.succeed(in._2)), listener)(
+                   _ => Duration.Infinity,
+                   keyBy = _._1
+                 )
+        _ <- cache.get((42, "a"))
+        _ <- cache.get((42, "b"))
+        a <- cache.get((42, "c"))
+      } yield assertTrue(
+        a == "a",
+        listener.misses.get == 1,
+        listener.hits.get == 2
+      )
+    },
+    test("a listener that throws does not affect the cache") {
+      val listener = new CacheListener[Any, Any, Any] {
+        override def onHit(key: Any)(implicit unsafe: Unsafe): Unit  = throw new RuntimeException("onHit")
+        override def onMiss(key: Any)(implicit unsafe: Unsafe): Unit = throw new RuntimeException("onMiss")
+        override def onLoad(key: Any, exit: Exit[Any, Any], loadTime: JDuration)(implicit u: Unsafe): Unit =
+          throw new RuntimeException("onLoad")
+        override def onEviction(key: Any, cause: EvictionCause)(implicit unsafe: Unsafe): Unit =
+          throw new RuntimeException("onEviction")
+      }
+      for {
+        cache <- Cache.make(100, Duration.Infinity, Lookup(identity), listener)
+        a     <- cache.get(42)
+        b     <- cache.get(42)
+        _     <- cache.invalidate(42)
+        stats <- cache.cacheStats
+      } yield assertTrue(a == 42, b == 42, stats.hits == 1L, stats.misses == 1L)
+    },
+    test("metrics listener reports cache events with ZIO metrics") {
+      val name = "metrics-listener-spec"
+      for {
+        cache  <- Cache.make(100, Duration.Infinity, Lookup(identity), CacheListener.metrics(name))
+        _      <- ZIO.foreachDiscard(List(1, 1, 2))(cache.get)
+        _      <- cache.invalidate(1)
+        hits   <- Metric.counter("zio_cache_hits").tagged("cache_name", name).value
+        misses <- Metric.counter("zio_cache_misses").tagged("cache_name", name).value
+        loads  <- Metric.counter("zio_cache_load_successes").tagged("cache_name", name).value
+        evictions <- Metric
+                       .counter("zio_cache_evictions")
+                       .tagged("cache_name", name)
+                       .tagged("cause", "invalidated")
+                       .value
+      } yield assertTrue(
+        hits.count == 1d,
+        misses.count == 2d,
+        loads.count == 2d,
+        evictions.count == 1d
+      )
+    }
+  )
+}

--- a/zio-cache/shared/src/test/scala/zio/cache/CacheListenerSpec.scala
+++ b/zio-cache/shared/src/test/scala/zio/cache/CacheListenerSpec.scala
@@ -19,29 +19,23 @@ object CacheListenerSpec extends ZIOSpecDefault {
     val expired       = new AtomicInteger(0)
     val invalidated   = new AtomicInteger(0)
 
-    override def onHit(key: Any)(implicit unsafe: Unsafe): Unit = {
-      hits.incrementAndGet()
-      ()
-    }
+    def onHit(key: Any): UIO[Unit] =
+      ZIO.succeed(hits.incrementAndGet()).unit
 
-    override def onMiss(key: Any)(implicit unsafe: Unsafe): Unit = {
-      misses.incrementAndGet()
-      ()
-    }
+    def onMiss(key: Any): UIO[Unit] =
+      ZIO.succeed(misses.incrementAndGet()).unit
 
-    override def onLoad(key: Any, exit: Exit[Any, Any], loadTime: JDuration)(implicit unsafe: Unsafe): Unit = {
-      if (exit.isSuccess) loadSuccesses.incrementAndGet() else loadFailures.incrementAndGet()
-      ()
-    }
+    def onLoad(key: Any, exit: Exit[Any, Any], loadTime: JDuration): UIO[Unit] =
+      ZIO.succeed(if (exit.isSuccess) loadSuccesses.incrementAndGet() else loadFailures.incrementAndGet()).unit
 
-    override def onEviction(key: Any, cause: EvictionCause)(implicit unsafe: Unsafe): Unit = {
-      cause match {
-        case EvictionCause.Capacity    => capacity.incrementAndGet()
-        case EvictionCause.Expired     => expired.incrementAndGet()
-        case EvictionCause.Invalidated => invalidated.incrementAndGet()
-      }
-      ()
-    }
+    def onEviction(key: Any, cause: EvictionCause): UIO[Unit] =
+      ZIO.succeed {
+        cause match {
+          case EvictionCause.Capacity    => capacity.incrementAndGet()
+          case EvictionCause.Expired     => expired.incrementAndGet()
+          case EvictionCause.Invalidated => invalidated.incrementAndGet()
+        }
+      }.unit
   }
 
   def hash(x: Int): Int => UIO[Int] =
@@ -129,6 +123,18 @@ object CacheListenerSpec extends ZIOSpecDefault {
         _     <- cache.invalidate(43)
       } yield assertTrue(listener.invalidated.get == 1)
     },
+    test("eviction events for invalidateAll") {
+      val listener = new TestListener
+      for {
+        cache <- Cache.make(100, Duration.Infinity, Lookup(identity), listener)
+        _     <- ZIO.foreachDiscard(1 to 10)(cache.get)
+        _     <- cache.invalidateAll
+        size  <- cache.size
+      } yield assertTrue(
+        size == 0,
+        listener.invalidated.get == 10
+      )
+    },
     test("listener is notified with the keys produced by the keying function") {
       val listener = new TestListener
       for {
@@ -145,14 +151,12 @@ object CacheListenerSpec extends ZIOSpecDefault {
         listener.hits.get == 2
       )
     },
-    test("a listener that throws does not affect the cache") {
+    test("a failing listener does not affect the cache") {
       val listener = new CacheListener[Any, Any, Any] {
-        override def onHit(key: Any)(implicit unsafe: Unsafe): Unit  = throw new RuntimeException("onHit")
-        override def onMiss(key: Any)(implicit unsafe: Unsafe): Unit = throw new RuntimeException("onMiss")
-        override def onLoad(key: Any, exit: Exit[Any, Any], loadTime: JDuration)(implicit u: Unsafe): Unit =
-          throw new RuntimeException("onLoad")
-        override def onEviction(key: Any, cause: EvictionCause)(implicit unsafe: Unsafe): Unit =
-          throw new RuntimeException("onEviction")
+        def onHit(key: Any): UIO[Unit]                                             = throw new RuntimeException("onHit")
+        def onMiss(key: Any): UIO[Unit]                                            = ZIO.dieMessage("onMiss")
+        def onLoad(key: Any, exit: Exit[Any, Any], loadTime: JDuration): UIO[Unit] = ZIO.dieMessage("onLoad")
+        def onEviction(key: Any, cause: EvictionCause): UIO[Unit]                  = throw new RuntimeException("onEviction")
       }
       for {
         cache <- Cache.make(100, Duration.Infinity, Lookup(identity), listener)
@@ -161,7 +165,7 @@ object CacheListenerSpec extends ZIOSpecDefault {
         _     <- cache.invalidate(42)
         stats <- cache.cacheStats
       } yield assertTrue(a == 42, b == 42, stats.hits == 1L, stats.misses == 1L)
-    },
+    } @@ TestAspect.silentLogging,
     test("metrics listener reports cache events with ZIO metrics") {
       val name = "metrics-listener-spec"
       for {


### PR DESCRIPTION
## Motivation

Currently the only way to observe cache activity is polling `cacheStats`, which exposes just cumulative hit/miss counters. There is no way to react to individual cache events, so common operational needs are impossible to express:

- exporting hits/misses/load durations to a metrics backend (Prometheus, Micrometer, ZIO metrics) with proper tags,
- observing evictions and invalidations (requested in #44, attempted in #57),
- measuring lookup latency, including failed lookups.

## Changes

This PR adds a `CacheListener` that is notified of cache events:

```scala
trait CacheListener[-Key, -Error, -Value] {
  def onHit(key: Key)(implicit unsafe: Unsafe): Unit
  def onMiss(key: Key)(implicit unsafe: Unsafe): Unit
  def onLoad(key: Key, exit: Exit[Error, Value], loadTime: Duration)(implicit unsafe: Unsafe): Unit
  def onEviction(key: Key, cause: CacheListener.EvictionCause)(implicit unsafe: Unsafe): Unit
}
```

- `onLoad` fires for every completed lookup (both `get` misses and `refresh`) with the resulting `Exit` and the time the lookup took.
- `onEviction` carries the cause: `Capacity`, `Expired`, or `Invalidated`.
- A ready-made `CacheListener.metrics(cacheName)` reports all events with ZIO metrics (`zio_cache_hits`, `zio_cache_misses`, `zio_cache_load_successes`, `zio_cache_load_failures`, `zio_cache_load_duration`, `zio_cache_evictions`), tagged with the cache name.
- A listener is attached via new overloads of `Cache.make`, `makeWith`, and `makeWithKey`; with `makeWithKey` the listener observes the keys produced by the `keyBy` function.

## Design notes

- **Listeners are synchronous side-effecting callbacks**, not ZIO effects. Hits and evictions are tracked on the non-effectful hot path of the cache (`getUnsafe`, the eviction loop in `trackAccess`), where running effects would require either blocking the eviction loop on user code or giving up the zero-allocation hit path. This mirrors Caffeine's `StatsCounter`. An effectful adapter (e.g. forking a handler on a `Runtime`) can be layered on top later without breaking anything.
- **All methods have no-op defaults**, so listeners override only the events they care about, and future events can be added without breaking existing implementations.
- **A listener that throws cannot corrupt the cache**: exceptions are caught around every notification, so promises are always completed and the internal state stays consistent.
- Existing constructors are untouched (binary and source compatible); the only MiMa filter added is for the private `CacheImplementation` class (its constructor gained a parameter).
- `invalidateAll` does not emit per-key events since the underlying map is cleared wholesale; this is documented.
