### PR TITLE
Target Java 17 bytecode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val zioCache = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     ),
     scalacOptions ++= Seq(
       "-release",
-      "11"
+      "17"
     ),
     scalacOptions ++=
       (if (scalaBinaryVersion.value == "3")


### PR DESCRIPTION
## Summary

#236 dropped JDK 11 from the CI matrix, but the compiler was still emitting Java 11 bytecode:

```scala
scalacOptions ++= Seq(
  "-release",
  "11"
),
```

This raises the bytecode target to 17 so it matches the JDKs actually supported and tested (17, 21, 25).

## ⚠️ Compatibility note

This is a user-visible change, not just CI hygiene. `-release` sets the **bytecode target**, so today's artifacts still run on a Java 11 runtime. After this change, zio-cache requires **Java 17 or newer at runtime** for consumers.

That follows from dropping JDK 11 support, but it is a breaking change for anyone still on Java 11 and should land in a release whose notes say so.

## Verification

Run locally on JDK 17:

- `+Test/compile` — clean across 2.12 / 2.13 / 3.3
- `++2.13 zioCacheJVM/test` — 47 tests passed, 0 failed
